### PR TITLE
clean delete binary in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,4 +41,4 @@ clean:
 	rm -f *.o *.d
 	rm -f libsqlite3.a
 	rm -f libvfs-ramcloud.a
-	rm -f test test2 test3 download upload
+	rm -f test test2 test3 download upload delete


### PR DESCRIPTION
Clean delete binary when run 'make clean' for ramcloud-sqlite3 project.
